### PR TITLE
Alternate Buffer

### DIFF
--- a/examples/src/file_explorer/file_explorer.adb
+++ b/examples/src/file_explorer/file_explorer.adb
@@ -23,5 +23,6 @@ begin
    Explorer.On_Draw (Surface, The_Area);
    Malef.Window.Window.Set_Group ([Malef.Groups.Layer (Surface)]);
    Malef.Window.Window.Display;
+   delay 5.0;
    Malef.System.Finalize;
 end File_Explorer;

--- a/examples/src/gradient.adb
+++ b/examples/src/gradient.adb
@@ -56,5 +56,6 @@ begin
    Malef.Window.Window.Set_Group ([Malef.Groups.Layer (Col_Surf, (1, 1)),
                                    Malef.Groups.Layer (Pal_Surf, (1, Width))]);
    Malef.Window.Window.Display;
+   delay 5.0;
    Malef.System.Finalize;
 end Gradient;

--- a/examples/src/rgb_window.adb
+++ b/examples/src/rgb_window.adb
@@ -23,6 +23,7 @@ begin
    -- to pass a function to the `Process_Group` procedure.
    Malef.Window.Window.Display;
 
+   delay 5.0;
    Malef.System.Finalize;        -- Finalize the subsystem
 
 end RGB_Window;

--- a/examples/src/texts.adb
+++ b/examples/src/texts.adb
@@ -47,6 +47,7 @@ begin
    -- Put_Line (Surface'Wide_Wide_Image);
    -- New_Line;
 
+   delay 5.0;
    Malef.System.Finalize;
 
 end Texts;

--- a/src/subsystems/ansi/malef-platform-terminal-output.adb
+++ b/src/subsystems/ansi/malef-platform-terminal-output.adb
@@ -194,6 +194,7 @@ package body Malef.Platform.Terminal.Output is
    procedure Initialize is
    begin
       -- TODO: Call termios
+      Buffer.Put (ASCII.ESC & "[?1049h");
       Format (7, 0, [others => False]);
       Move_To (1, 1);
       Opened_Frames := 0;
@@ -206,7 +207,8 @@ package body Malef.Platform.Terminal.Output is
       -- TODO: Call termios
       Buffer.Put (ASCII.ESC & "[0m"     -- Clear format
                 & ASCII.ESC & "[?12h"   -- Restore terminal
-                & ASCII.ESC & "[?25h"); -- Make cursor visible
+                & ASCII.ESC & "[?25h"   -- Make cursor visible
+                & ASCII.ESC & "[?1049l");
       Flush;
    end Finalize;
 

--- a/src/subsystems/ansi/malef-platform-terminal-output.adb
+++ b/src/subsystems/ansi/malef-platform-terminal-output.adb
@@ -197,7 +197,7 @@ package body Malef.Platform.Terminal.Output is
       Format (7, 0, [others => False]);
       Move_To (1, 1);
       Opened_Frames := 0;
-      Buffer.Put (ASCII.ESC & "[25l");
+      Buffer.Put (ASCII.ESC & "[?25l"); -- Make cursor invisible
       Flush;
    end Initialize;
 
@@ -206,7 +206,7 @@ package body Malef.Platform.Terminal.Output is
       -- TODO: Call termios
       Buffer.Put (ASCII.ESC & "[0m"     -- Clear format
                 & ASCII.ESC & "[?12h"   -- Restore terminal
-                & ASCII.ESC & "[?25h");
+                & ASCII.ESC & "[?25h"); -- Make cursor visible
       Flush;
    end Finalize;
 

--- a/src/subsystems/ansi/malef-platform-terminal-output.adb
+++ b/src/subsystems/ansi/malef-platform-terminal-output.adb
@@ -196,7 +196,6 @@ package body Malef.Platform.Terminal.Output is
       -- TODO: Call termios
       Buffer.Put (ASCII.ESC & "[?1049h");
       Format (7, 0, [others => False]);
-      Move_To (1, 1);
       Opened_Frames := 0;
       Buffer.Put (ASCII.ESC & "[?25l"); -- Make cursor invisible
       Flush;
@@ -205,9 +204,7 @@ package body Malef.Platform.Terminal.Output is
    procedure Finalize is
    begin
       -- TODO: Call termios
-      Buffer.Put (ASCII.ESC & "[0m"     -- Clear format
-                & ASCII.ESC & "[?12h"   -- Restore terminal
-                & ASCII.ESC & "[?25h"   -- Make cursor visible
+      Buffer.Put (ASCII.ESC & "[?25h"   -- Make cursor visible
                 & ASCII.ESC & "[?1049l");
       Flush;
    end Finalize;


### PR DESCRIPTION
I don't know if you are taking pull requests.
I was playing around with your library and noticed there was a '?' character missing on one of the escape sequences so the cursor remained visible all the time.
I also added the escape sequences to change to and from the alternate buffer and deleted the lines that (I think) become unnecessary after making this change. I added delays to the examples.